### PR TITLE
Cli app updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 description = "MYA web-based query tool"
-version = '2.6.1'
+version = '3.0.0'
 
 ext {
     releaseDate = 'Jan 24 2023'
@@ -35,7 +35,7 @@ configurations {
 }
 
 dependencies {
-    implementation 'org.jlab:jmyapi:6.2.0',
+    implementation 'org.jlab:jmyapi:6.3.0',
                    'org.eclipse.parsson:parsson:1.1.1'
 	providedCompile 'jakarta.servlet:jakarta.servlet-api:6.0.0'
     testImplementation 'junit:junit:4.13.2'

--- a/src/integration/java/org/jlab/myquery/IntervalQueryTest.java
+++ b/src/integration/java/org/jlab/myquery/IntervalQueryTest.java
@@ -35,6 +35,59 @@ public class IntervalQueryTest {
     }
 
     @Test
+    public void doMySamplerTest() throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder().uri(URI.create("http://localhost:8080/myquery/interval?c=channel1&b=2019-08-12+23%3A59%3A00&e=2019-08-13&l=5&t=mysampler&m=docker&f=6&v=")).build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+
+        String jsonString = """
+                {
+                            "datatype": "DBR_DOUBLE",
+                                "datasize": 1,
+                                "datahost": "mya",
+                                "ioc": null,
+                                "active": true,
+                                "sampled": true,
+                                "count": 33,
+                                "sampleType": "mysampler",
+                                "data": [
+                            {
+                                "d": "2019-08-12 23:59:00.000000",
+                                    "v": 94.550102
+                            },
+                            {
+                                "d": "2019-08-12 23:59:15.000000",
+                                    "v": 94.987701
+                            },
+                            {
+                                "d": "2019-08-12 23:59:30.000000",
+                                    "v": 94.651604
+                            },
+                            {
+                                "d": "2019-08-12 23:59:45.000000",
+                                    "v": 94.292702
+                            },
+                            {
+                                "d": "2019-08-13 00:00:00.000000",
+                                    "v": 95.179703
+                            }
+                  ],
+                            "returnCount": 5
+                        }""";
+        String exp;
+        try(JsonReader r = Json.createReader(new StringReader(jsonString))) {
+            exp = r.readObject().toString();
+        }
+
+        try(JsonReader reader = Json.createReader(new StringReader(response.body()))) {
+            JsonObject json = reader.readObject();
+            assertEquals(exp, json.toString());
+        }
+    }
+
+    @Test
     public void doWithTimeTest() throws IOException, InterruptedException {
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest.newBuilder().uri(URI.create("http://localhost:8080/myquery/interval?m=docker&c=channel4&b=2023-01-17+00%3A00%3A00&e=2023-01-17+02%3A10%3A00")).build();

--- a/src/integration/java/org/jlab/myquery/MySamplerQueryTest.java
+++ b/src/integration/java/org/jlab/myquery/MySamplerQueryTest.java
@@ -1,0 +1,67 @@
+package org.jlab.myquery;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.junit.Assert.assertEquals;
+
+public class MySamplerQueryTest {
+    @Test
+    public void basicUsageTest() throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder().uri(URI.create("http://localhost:8080/myquery/mysampler?c=channel1&b=2019-08-12+23%3A59%3A00&n=5&s=15000&m=docker&f=6&v=")).build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+
+        String jsonString = """
+                {
+                            "datatype": "DBR_DOUBLE",
+                                "datasize": 1,
+                                "datahost": "mya",
+                                "ioc": null,
+                                "active": true,
+                                "data": [
+                            {
+                                "d": "2019-08-12 23:59:00.000000",
+                                    "v": 94.550102
+                            },
+                            {
+                                "d": "2019-08-12 23:59:15.000000",
+                                    "v": 94.987701
+                            },
+                            {
+                                "d": "2019-08-12 23:59:30.000000",
+                                    "v": 94.651604
+                            },
+                            {
+                                "d": "2019-08-12 23:59:45.000000",
+                                    "v": 94.292702
+                            },
+                            {
+                                "d": "2019-08-13 00:00:00.000000",
+                                    "v": 95.179703
+                            }
+                  ],
+                            "returnCount": 5
+                        }""";
+        String exp;
+        try(JsonReader r = Json.createReader(new StringReader(jsonString))) {
+            exp = r.readObject().toString();
+        }
+
+        try(JsonReader reader = Json.createReader(new StringReader(response.body()))) {
+            JsonObject json = reader.readObject();
+            assertEquals(exp, json.toString());
+        }
+    }
+}

--- a/src/integration/java/org/jlab/myquery/MyStatsQueryTest.java
+++ b/src/integration/java/org/jlab/myquery/MyStatsQueryTest.java
@@ -1,0 +1,107 @@
+package org.jlab.myquery;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.junit.Assert.assertEquals;
+
+public class MyStatsQueryTest {
+    @Test
+    public void basicUsageTest() throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder().uri(URI.create("http://localhost:8080/myquery/mystats?c=channel1&b=2019-08-12&e=2019-08-12+01%3A00%3A00&n=5&m=docker&f=3&v=2")).build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+
+        String jsonString = """
+                {
+                                           "datatype": "DBR_DOUBLE",
+                                           "datasize": 1,
+                                           "datahost": "mya",
+                                           "ioc": null,
+                                           "active": true,
+                                           "data": [
+                                             {
+                                               "begin": "2019-08-12 00:00:00.000",
+                                               "eventCount": 335,
+                                               "updateCount": 334,
+                                               "duration": 719.13,
+                                               "integration": 68755.14,
+                                               "max": 96.81,
+                                               "mean": 95.61,
+                                               "min": 94.43,
+                                               "rms": 95.61,
+                                               "stdev": 0.44
+                                             },
+                                             {
+                                               "begin": "2019-08-12 00:12:00.000",
+                                               "eventCount": 369,
+                                               "updateCount": 368,
+                                               "duration": 719.12,
+                                               "integration": 68944.14,
+                                               "max": 96.85,
+                                               "mean": 95.87,
+                                               "min": 94.94,
+                                               "rms": 95.87,
+                                               "stdev": 0.39
+                                             },
+                                             {
+                                               "begin": "2019-08-12 00:24:00.000",
+                                               "eventCount": 343,
+                                               "updateCount": 342,
+                                               "duration": 718.11,
+                                               "integration": 68751.67,
+                                               "max": 96.89,
+                                               "mean": 95.74,
+                                               "min": 95.01,
+                                               "rms": 95.74,
+                                               "stdev": 0.35
+                                             },
+                                             {
+                                               "begin": "2019-08-12 00:36:00.000",
+                                               "eventCount": 317,
+                                               "updateCount": 316,
+                                               "duration": 718.07,
+                                               "integration": 65907.67,
+                                               "max": 96.95,
+                                               "mean": 91.78,
+                                               "min": 0,
+                                               "rms": 93.27,
+                                               "stdev": 16.59
+                                             },
+                                             {
+                                               "begin": "2019-08-12 00:48:00.000",
+                                               "eventCount": 352,
+                                               "updateCount": 351,
+                                               "duration": 714.12,
+                                               "integration": 68422.19,
+                                               "max": 96.9,
+                                               "mean": 95.81,
+                                               "min": 94.85,
+                                               "rms": 95.81,
+                                               "stdev": 0.45
+                                             }
+                                           ],
+                                           "returnCount": 5
+                                         }""";
+        String exp;
+        try (JsonReader r = Json.createReader(new StringReader(jsonString))) {
+            exp = r.readObject().toString();
+        }
+
+        try (JsonReader reader = Json.createReader(new StringReader(response.body()))) {
+            JsonObject json = reader.readObject();
+            assertEquals(exp, json.toString());
+        }
+    }
+}

--- a/src/main/java/org/jlab/myquery/IntervalController.java
+++ b/src/main/java/org/jlab/myquery/IntervalController.java
@@ -119,7 +119,7 @@ public class IntervalController extends QueryController {
             boolean updatesOnly = (d != null);
             boolean enumsAsStrings = (s != null);
 
-            if (p != null) { // Include prior point
+            if (p != null || (t != null && t.equals("mysampler"))) { // Include prior point
                 PointWebService pointService = new PointWebService(deployment);
                 priorEvent = pointService.findEvent(metadata, updatesOnly, begin, true, false, enumsAsStrings);
             }
@@ -150,7 +150,7 @@ public class IntervalController extends QueryController {
                 }
             }
 
-            boolean integrate = i != null && !t.trim().isEmpty();
+            boolean integrate = i != null && (t != null && !t.trim().isEmpty());
 
             Class type = metadata.getType();
 

--- a/src/main/java/org/jlab/myquery/IntervalWebService.java
+++ b/src/main/java/org/jlab/myquery/IntervalWebService.java
@@ -12,7 +12,6 @@ import org.jlab.mya.nexus.DataNexus;
 import org.jlab.mya.stream.*;
 
 /**
- *
  * @author adamc, ryans
  */
 public class IntervalWebService extends QueryWebService {
@@ -36,7 +35,7 @@ public class IntervalWebService extends QueryWebService {
                                                             T priorEvent, Class<T> type) throws Exception {
         EventStream stream = nexus.openEventStream(metadata, begin, end, DataNexus.IntervalQueryFetchStrategy.STREAM, updatesOnly);
 
-        if(priorEvent != null) {
+        if (priorEvent != null) {
             stream = new BoundaryAwareStream(stream, begin, end, priorEvent, updatesOnly, type);
         }
 
@@ -49,23 +48,27 @@ public class IntervalWebService extends QueryWebService {
 
 
     public EventStream<FloatEvent> openSampleEventStream(String sampleType, Metadata<FloatEvent> metadata, Instant begin, Instant end, long limit,
-            long count, boolean updatesOnly, boolean integrate, FloatEvent priorEvent, Class<FloatEvent> type) throws SQLException, UnsupportedOperationException {
+                                                         long count, boolean updatesOnly, boolean integrate, FloatEvent priorEvent, Class<FloatEvent> type) throws SQLException, UnsupportedOperationException {
 
         EventStream<FloatEvent> stream;
 
-        if (sampleType == null || sampleType.isEmpty()){
+        if (sampleType == null || sampleType.isEmpty()) {
             throw new IllegalArgumentException("sampleType required.  Options include graphical, event, binned");
         }
 
-        switch(sampleType) {
+        switch (sampleType) {
+            case "mysampler": // Now application-level time-based. Results in one query against database.
+                // Takes value at timed intervals (by looking for prior point)
+                if (integrate) {
+                    throw new UnsupportedOperationException("Integration of input into mysampler algorithm has not been implemented");
+                }
             case "graphical":  // Application-level event-based, high graphical fidelity
             case "eventsimple": // Application-level event-based. This is likely never a good sampler option given above...
                 stream = doApplicationSampling(sampleType, metadata, begin, end, limit, count, updatesOnly, integrate, priorEvent, type);
                 break;
             case "myget": // Database-level time-based.  Stored Procedure: Fastest.  "Basic" graphical fidelity.  Takes first/next actual point at timed intervals
-            case "mysampler": // Database-level time-based. Results in n-queries against database.  Takes value at timed intervals (by looking for prior point)
-                if(integrate) {
-                    throw new UnsupportedOperationException("Integration of input into myget sampler / mysampler algorithm has not been implemented");
+                if (integrate) {
+                    throw new UnsupportedOperationException("Integration of input into myget sampler algorithm has not been implemented");
                 }
 
                 stream = doDatabaseSourceSampling(sampleType, metadata, updatesOnly, begin, end, limit, priorEvent, FloatEvent.class);
@@ -79,11 +82,12 @@ public class IntervalWebService extends QueryWebService {
 
     @SuppressWarnings("unchecked")
     private EventStream<FloatEvent> doApplicationSampling(String sampleType, Metadata metadata, Instant begin, Instant end, long limit,
-                                              long count, boolean updatesOnly, boolean integrate, FloatEvent priorEvent, Class<FloatEvent> type) throws SQLException {
+                                                          long count, boolean updatesOnly, boolean integrate, FloatEvent priorEvent, Class<FloatEvent> type) throws SQLException {
 
         EventStream<FloatEvent> stream = nexus.openEventStream(metadata, begin, end);
 
-        if(priorEvent != null) {
+        // Don't do this for mysampler as it extends BoundaryAwareStream and requires a non-null priorEvent.
+        if (priorEvent != null && !sampleType.equals("mysampler")) {
             stream = new BoundaryAwareStream<>(stream, begin, end, priorEvent, updatesOnly, type);
         }
 
@@ -94,12 +98,18 @@ public class IntervalWebService extends QueryWebService {
             type2 = AnalyzedFloatEvent.class;
         }
 
-        switch(sampleType) {
+        switch (sampleType) {
             case "graphical":  // Application-level event-based, high graphical fidelity
                 stream = new FloatGraphicalSampleStream(stream, limit, count, type2);
                 break;
             case "eventsimple": // Application-level event-based. This is likely never a good sampler option given above...
                 stream = new FloatSimpleSampleStream(stream, limit, count, type2);
+                break;
+            case "mysampler": // Application-level event-based.  This mimics the CLI mySampler output.
+                double endD = (end.getEpochSecond() + end.getNano() / 1_000_000_000d);
+                double beginD = (begin.getEpochSecond() + begin.getNano() / 1_000_000_000d);
+                long stepMillis = (long) (((endD - beginD) / (limit - 1)) * 1000);
+                stream = new MySamplerStream<FloatEvent>(stream, begin, stepMillis, limit, priorEvent, updatesOnly, FloatEvent.class);
                 break;
             default:
                 throw new IllegalArgumentException("Unrecognized sampleType - " + sampleType + ".  Options include graphical, eventsimple, myget, mysampler");
@@ -109,22 +119,18 @@ public class IntervalWebService extends QueryWebService {
     }
 
     private EventStream<FloatEvent> doDatabaseSourceSampling(String sampleType, Metadata<FloatEvent> metadata, boolean updatesOnly, Instant begin, Instant end, long limit,
-                                                 FloatEvent priorEvent, Class<FloatEvent> type) throws SQLException {
+                                                             FloatEvent priorEvent, Class<FloatEvent> type) throws SQLException {
         EventStream<FloatEvent> stream;
 
-        switch(sampleType) {
+        switch (sampleType) {
             case "myget": // Database-level time-based.  Stored Procedure: Fastest.  "Basic" graphical fidelity.  Takes first/next actual point at timed intervals
                 stream = nexus.openMyGetSampleStream(metadata, begin, end, limit);
                 break;
-            case "mysampler": // Database-level time-based. Results in n-queries against database.  Takes value at timed intervals (by looking for prior point)
-                long stepMillis = ((end.getEpochSecond() - begin.getEpochSecond()) / limit) * 1000;
-                stream = nexus.openMySamplerStream(metadata, begin, stepMillis, limit);
-                break;
             default:
-            throw new IllegalArgumentException("Unrecognized sampleType - " + sampleType + ".  Options include graphical, eventsimple, myget, mysampler");
+                throw new IllegalArgumentException("Unrecognized sampleType - " + sampleType + ".  Options include myget");
         }
 
-        if(priorEvent != null) {
+        if (priorEvent != null) {
             stream = new BoundaryAwareStream<>(stream, begin, end, priorEvent, updatesOnly, type);
         }
 

--- a/src/main/java/org/jlab/myquery/IntervalWebService.java
+++ b/src/main/java/org/jlab/myquery/IntervalWebService.java
@@ -109,7 +109,7 @@ public class IntervalWebService extends QueryWebService {
                 double endD = (end.getEpochSecond() + end.getNano() / 1_000_000_000d);
                 double beginD = (begin.getEpochSecond() + begin.getNano() / 1_000_000_000d);
                 long stepMillis = (long) (((endD - beginD) / (limit - 1)) * 1000);
-                stream = new MySamplerStream<FloatEvent>(stream, begin, stepMillis, limit, priorEvent, updatesOnly, FloatEvent.class);
+                stream = new MySamplerStream<>(stream, begin, stepMillis, limit, priorEvent, updatesOnly, FloatEvent.class);
                 break;
             default:
                 throw new IllegalArgumentException("Unrecognized sampleType - " + sampleType + ".  Options include graphical, eventsimple, myget, mysampler");

--- a/src/main/java/org/jlab/myquery/MySamplerController.java
+++ b/src/main/java/org/jlab/myquery/MySamplerController.java
@@ -60,7 +60,7 @@ public class MySamplerController extends QueryController {
         String n = request.getParameter("n"); // sampleCount
         String s = request.getParameter("s"); // intervalMillis
         String m = request.getParameter("m"); // deployment
-        String f = request.getParameter("f"); // timestampFormater (timestamp precision)
+        String f = request.getParameter("f"); // timestampFormatter (timestamp precision)
         String d = request.getParameter("d"); // updatesOnly
         String e = request.getParameter("e"); // enumsAsStrings
         String u = request.getParameter("u"); // formatAsMillisSinceEpoch

--- a/src/main/java/org/jlab/myquery/MySamplerController.java
+++ b/src/main/java/org/jlab/myquery/MySamplerController.java
@@ -1,0 +1,245 @@
+package org.jlab.myquery;
+
+import jakarta.json.Json;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.annotation.*;
+import org.jlab.mya.ExtraInfo;
+import org.jlab.mya.Metadata;
+import org.jlab.mya.MyaDataType;
+import org.jlab.mya.event.*;
+import org.jlab.mya.stream.EventStream;
+import org.jlab.mya.stream.LabeledEnumStream;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.text.DecimalFormat;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@WebServlet(name = "MySamplerController", value = "/mysampler")
+public class MySamplerController extends QueryController {
+
+    private static final Logger LOGGER = Logger.getLogger(MySamplerController.class.getName());
+
+    /**
+     * Handles the HTTP <code>GET</code> method.
+     *
+     * @param request  servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException      if an I/O error occurs
+     */
+    @SuppressWarnings({"unchecked"})
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        String jsonp = request.getParameter("jsonp");
+
+        if (jsonp != null) {
+            response.setContentType("application/javascript");
+        } else {
+            response.setContentType("application/json");
+        }
+
+        String errorReason = null;
+        EventStream stream = null;
+        Metadata metadata = null;
+        List<ExtraInfo> enumLabels = null;
+
+
+        String c = request.getParameter("c"); // channel
+        String b = request.getParameter("b"); // begin
+        String n = request.getParameter("n"); // sampleCount
+        String s = request.getParameter("s"); // intervalMillis
+        String m = request.getParameter("m"); // deployment
+        String f = request.getParameter("f"); // timestampFormater (timestamp precision)
+        String d = request.getParameter("d"); // updatesOnly
+        String e = request.getParameter("e"); // enumsAsStrings
+        String u = request.getParameter("u"); // formatAsMillisSinceEpoch
+        String a = request.getParameter("a"); // adjustMillisWithServerOffset
+        String v = request.getParameter("v"); // decimalFormatter (value precision)
+
+        try {
+            if (c == null || c.trim().isEmpty()) {
+                throw new Exception("Channel (c) is required");
+            }
+            if (b == null || b.trim().isEmpty()) {
+                throw new Exception("Begin Date (b) is required");
+            }
+            if (n == null || n.trim().isEmpty()) {
+                throw new Exception("Number of sampler (n) is required");
+            }
+            if (s == null || s.trim().isEmpty()) {
+                throw new Exception("Step size (s) in milliseconds is required");
+            }
+
+            // Replace ' ' with 'T' if present
+            b = b.replace(' ', 'T');
+
+            // If only date and no time then add explicit zero time
+            if (b.length() == 10) {
+                b = b + "T00:00:00";
+            }
+
+            Instant begin = LocalDateTime.parse(b).atZone(
+                    ZoneId.systemDefault()).toInstant();
+
+            String deployment = "ops";
+            if (m != null && !m.trim().isEmpty()) {
+                deployment = m;
+            }
+
+            MySamplerWebService service = new MySamplerWebService(deployment);
+
+            metadata = service.findMetadata(c);
+            if (metadata == null) {
+                throw new Exception("Unable to find channel: '" + c + "' in deployment: '" + deployment + "'");
+            }
+
+            long intervalMillis, sampleCount;
+            try {
+                intervalMillis = Long.parseLong(s);
+            } catch (NumberFormatException ex) {
+                throw new Exception("Error parsing sample interval (s) in milliseconds: '" + s + "'");
+            }
+            try {
+                sampleCount = Long.parseLong(n);
+            } catch (NumberFormatException ex) {
+                throw new Exception("Error parsing number of samples (n): '" + s + "'");
+            }
+
+            boolean updatesOnly = (d != null);
+            boolean enumsAsStrings = (e != null);
+
+            // Don't tell client to cache response if contains future bounds!
+            Instant end = begin.plusMillis(intervalMillis * (sampleCount - 1));
+            if (end.isAfter(Instant.now())) {
+                CacheAndEncodingFilter.disableCaching(response);
+            } else {
+                response.setHeader("Cache-Control", "private");
+            }
+
+            // Get the sampled stream.  If it's an enum convert to use string labels if requested.
+            stream = service.openEventStream(metadata, begin, intervalMillis, sampleCount, updatesOnly);
+            if(metadata.getMyaType() == MyaDataType.DBR_ENUM) {
+                enumLabels = service.findExtraInfo(metadata, "enum_strings", begin, end);
+                if (enumsAsStrings) {
+                    stream = new LabeledEnumStream((EventStream<IntEvent>) stream, enumLabels);
+                }
+            }
+
+
+        } catch (Exception ex) {
+            LOGGER.log(Level.SEVERE, "Unable to service request", ex);
+            errorReason = ex.getMessage();
+
+            try {
+                if (stream != null) {
+                    stream.close();
+                    stream = null;
+                }
+            } catch (Exception closeIssue) {
+                System.err.println("Unable to close stream");
+            }
+        }
+
+        DateTimeFormatter timestampFormatter = FormatUtil.getInstantFormatter(f);
+        DecimalFormat decimalFormatter = FormatUtil.getDecimalFormat(v);
+        boolean formatAsMillisSinceEpoch = (u != null);
+        boolean adjustMillisWithServerOffset = (a != null);
+
+        try {
+            OutputStream out = response.getOutputStream();
+
+            if (jsonp != null) {
+                out.write((jsonp + "(").getBytes(StandardCharsets.UTF_8));
+            }
+
+            try (JsonGenerator gen = Json.createGenerator(out)) {
+                gen.writeStartObject();
+
+                if (errorReason != null) {
+                    response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                    gen.write("error", errorReason);
+                } else {
+                    if (metadata != null) {
+                        gen.write("datatype", metadata.getMyaType().name());
+                        gen.write("datasize", metadata.getSize());
+                        gen.write("datahost", metadata.getHost());
+                        if (metadata.getIoc() == null) {
+                            gen.writeNull("ioc");
+                        } else {
+                            gen.write("ioc", metadata.getIoc());
+                        }
+                        gen.write("active", metadata.isActive());
+                    }
+
+                    if (enumLabels != null && enumLabels.size() > 0) {
+                        gen.writeStartArray("labels");
+                        for (ExtraInfo info : enumLabels) {
+                            gen.writeStartObject();
+                            FormatUtil.writeTimestampJSON(gen, "d", info.getTimestamp(), formatAsMillisSinceEpoch, adjustMillisWithServerOffset, timestampFormatter);
+                            gen.writeStartArray("value");
+                            for (String token : info.getValueAsArray()) {
+                                if (token != null && !token.isEmpty()) {
+                                    gen.write(token);
+                                }
+                            }
+                            gen.writeEnd();
+                            gen.writeEnd();
+                        }
+                        gen.writeEnd();
+                    }
+
+                    gen.writeStartArray("data");
+
+                    long dataLength = 0;
+                    if (stream == null) {
+                        // Didn't get a stream so presumably there is an errorReason
+                    } else if (stream.getType() == IntEvent.class) {
+                        dataLength = generateIntStream(gen, (EventStream<IntEvent>) stream, formatAsMillisSinceEpoch, adjustMillisWithServerOffset,
+                                timestampFormatter);
+                    } else if (stream.getType() == FloatEvent.class) {
+                        dataLength = generateFloatStream(gen, (EventStream<FloatEvent>) stream, formatAsMillisSinceEpoch, adjustMillisWithServerOffset,
+                                timestampFormatter, decimalFormatter);
+                    } else if (stream.getType() == AnalyzedFloatEvent.class) {
+                        dataLength = generateAnalyzedFloatStream(gen, (EventStream<AnalyzedFloatEvent>) stream, formatAsMillisSinceEpoch, adjustMillisWithServerOffset,
+                                timestampFormatter, decimalFormatter);
+                    } else if (stream.getType() == LabeledEnumEvent.class) {
+                        dataLength = generateLabeledEnumStream(gen, (EventStream<LabeledEnumEvent>) stream, formatAsMillisSinceEpoch, adjustMillisWithServerOffset, timestampFormatter);
+                    } else if (stream.getType() == MultiStringEvent.class) {
+                        dataLength = generateMultiStringStream(gen, (EventStream<MultiStringEvent>) stream, formatAsMillisSinceEpoch, adjustMillisWithServerOffset,
+                                timestampFormatter);
+                    } else {
+                        throw new ServletException("Unsupported data type: " + stream.getClass());
+                    }
+                    gen.writeEnd();
+
+                    gen.write("returnCount", dataLength);
+                }
+                gen.writeEnd();
+
+                gen.flush();
+            }
+            if (jsonp != null) {
+                out.write((");").getBytes(StandardCharsets.UTF_8));
+            }
+        } finally {
+            try {
+                if (stream != null) {
+                    stream.close();
+                }
+            } catch (Exception closeIssue) {
+                System.err.println("Unable to close stream");
+            }
+        }
+    }
+}

--- a/src/main/java/org/jlab/myquery/MySamplerController.java
+++ b/src/main/java/org/jlab/myquery/MySamplerController.java
@@ -113,7 +113,7 @@ public class MySamplerController extends QueryController {
             try {
                 sampleCount = Long.parseLong(n);
             } catch (NumberFormatException ex) {
-                throw new Exception("Error parsing number of samples (n): '" + s + "'");
+                throw new Exception("Error parsing number of samples (n): '" + n + "'");
             }
 
             boolean updatesOnly = (d != null);

--- a/src/main/java/org/jlab/myquery/MySamplerController.java
+++ b/src/main/java/org/jlab/myquery/MySamplerController.java
@@ -24,6 +24,10 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * This method provides an end point for functionality similar to the mySampler command line application.
+ * @author adamc
+ */
 @WebServlet(name = "MySamplerController", value = "/mysampler")
 public class MySamplerController extends QueryController {
 

--- a/src/main/java/org/jlab/myquery/MySamplerWebService.java
+++ b/src/main/java/org/jlab/myquery/MySamplerWebService.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 /**
  * This class provides features similar to the mySampler command line utility.
+ * @author adamc
  */
 public class MySamplerWebService extends QueryWebService {
 

--- a/src/main/java/org/jlab/myquery/MySamplerWebService.java
+++ b/src/main/java/org/jlab/myquery/MySamplerWebService.java
@@ -1,0 +1,45 @@
+package org.jlab.myquery;
+
+import org.jlab.mya.ExtraInfo;
+import org.jlab.mya.Metadata;
+import org.jlab.mya.RunningStatistics;
+import org.jlab.mya.event.AnalyzedFloatEvent;
+import org.jlab.mya.event.Event;
+import org.jlab.mya.event.FloatEvent;
+import org.jlab.mya.nexus.DataNexus;
+import org.jlab.mya.stream.*;
+
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.List;
+
+public class MySamplerWebService extends QueryWebService {
+
+    private final DataNexus nexus;
+
+    public MySamplerWebService(String deployment) {
+        nexus = getNexus(deployment);
+    }
+
+    public Metadata findMetadata(String c) throws SQLException {
+        return nexus.findMetadata(c);
+    }
+
+    public List<ExtraInfo> findExtraInfo(Metadata metadata, String type, Instant begin, Instant end) throws SQLException {
+        return nexus.findExtraInfo(metadata, type, begin, end);
+    }
+
+
+    @SuppressWarnings("unchecked")
+    public <T extends Event> EventStream<T> openEventStream(Metadata<T> metadata, Instant begin, long intervalMillis,
+                                                            long sampleCount, boolean updatesOnly) throws SQLException, UnsupportedOperationException {
+
+        PointWebService pws = new PointWebService(nexus.getDeployment());
+        T priorEvent = (T) pws.findEvent(metadata, updatesOnly, begin, true, false, false);
+
+        Instant end = begin.plusMillis(intervalMillis * (sampleCount - 1));
+        EventStream<T> stream = nexus.openEventStream(metadata, begin, end, DataNexus.IntervalQueryFetchStrategy.STREAM, updatesOnly);
+
+        return new MySamplerStream<>(stream, begin, intervalMillis, sampleCount, priorEvent, updatesOnly, metadata.getType());
+    }
+}

--- a/src/main/java/org/jlab/myquery/MySamplerWebService.java
+++ b/src/main/java/org/jlab/myquery/MySamplerWebService.java
@@ -2,17 +2,16 @@ package org.jlab.myquery;
 
 import org.jlab.mya.ExtraInfo;
 import org.jlab.mya.Metadata;
-import org.jlab.mya.RunningStatistics;
-import org.jlab.mya.event.AnalyzedFloatEvent;
 import org.jlab.mya.event.Event;
-import org.jlab.mya.event.FloatEvent;
 import org.jlab.mya.nexus.DataNexus;
 import org.jlab.mya.stream.*;
-
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.List;
 
+/**
+ * This class provides features similar to the mySampler command line utility.
+ */
 public class MySamplerWebService extends QueryWebService {
 
     private final DataNexus nexus;

--- a/src/main/java/org/jlab/myquery/MyStatsController.java
+++ b/src/main/java/org/jlab/myquery/MyStatsController.java
@@ -2,13 +2,11 @@ package org.jlab.myquery;
 
 import jakarta.json.Json;
 import jakarta.json.stream.JsonGenerator;
-import jakarta.servlet.*;
 import jakarta.servlet.http.*;
 import jakarta.servlet.annotation.*;
 import org.jlab.mya.Metadata;
 import org.jlab.mya.RunningStatistics;
 import org.jlab.mya.event.*;
-import org.jlab.mya.stream.EventStream;
 import org.jlab.mya.stream.FloatAnalysisStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -31,13 +29,12 @@ public class MyStatsController extends QueryController {
      *
      * @param request  servlet request
      * @param response servlet response
-     * @throws ServletException if a servlet-specific error occurs
      * @throws IOException      if an I/O error occurs
      */
     @SuppressWarnings({"unchecked"})
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
+            throws IOException {
         String jsonp = request.getParameter("jsonp");
 
         if (jsonp != null) {
@@ -47,7 +44,6 @@ public class MyStatsController extends QueryController {
         }
 
         String errorReason = null;
-        EventStream stream = null;
         Metadata metadata = null;
         Map<Instant, RunningStatistics> stats = new TreeMap<>();  // TreeMap results in bin sorted JSON response.
 
@@ -155,15 +151,6 @@ public class MyStatsController extends QueryController {
         } catch (Exception ex) {
             LOGGER.log(Level.SEVERE, "Unable to service request", ex);
             errorReason = ex.getMessage();
-
-            try {
-                if (stream != null) {
-                    stream.close();
-                    stream = null;
-                }
-            } catch (Exception closeIssue) {
-                System.err.println("Unable to close stream");
-            }
         }
 
         DateTimeFormatter timestampFormatter = FormatUtil.getInstantFormatter(f);

--- a/src/main/java/org/jlab/myquery/MyStatsController.java
+++ b/src/main/java/org/jlab/myquery/MyStatsController.java
@@ -1,0 +1,219 @@
+package org.jlab.myquery;
+
+import jakarta.json.Json;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.annotation.*;
+import org.jlab.mya.Metadata;
+import org.jlab.mya.RunningStatistics;
+import org.jlab.mya.event.*;
+import org.jlab.mya.stream.EventStream;
+import org.jlab.mya.stream.FloatAnalysisStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.text.DecimalFormat;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@WebServlet(name = "MyStatsController", value = "/mystats")
+public class MyStatsController extends QueryController {
+    private static final Logger LOGGER = Logger.getLogger(MyStatsController.class.getName());
+
+    /**
+     * Handles the HTTP <code>GET</code> method.
+     *
+     * @param request  servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException      if an I/O error occurs
+     */
+    @SuppressWarnings({"unchecked"})
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        String jsonp = request.getParameter("jsonp");
+
+        if (jsonp != null) {
+            response.setContentType("application/javascript");
+        } else {
+            response.setContentType("application/json");
+        }
+
+        String errorReason = null;
+        EventStream stream = null;
+        Metadata metadata = null;
+        Map<Instant, RunningStatistics> stats = new TreeMap<>();  // TreeMap results in bin sorted JSON response.
+
+
+        String c = request.getParameter("c"); // channel
+        String b = request.getParameter("b"); // begin
+        String e = request.getParameter("e"); // end
+        String n = request.getParameter("n"); // number of bins
+        String m = request.getParameter("m"); // deployment
+        String d = request.getParameter("d"); // updatesOnly
+        String f = request.getParameter("f"); // TimestampFormatter
+        String u = request.getParameter("u"); // formatAsMillisSinceEpoch
+        String a = request.getParameter("a"); // adjustMillisWithServerOffset
+        String v = request.getParameter("v"); // decimalFormatter (value precision)
+
+        try {
+            if (c == null || c.trim().isEmpty()) {
+                throw new Exception("Channel (c) is required");
+            }
+            if (b == null || b.trim().isEmpty()) {
+                throw new Exception("Begin Date (b) is required");
+            }
+            if (e == null || e.trim().isEmpty()) {
+                throw new Exception("End Date (e) is required");
+            }
+
+            // Replace ' ' with 'T' if present
+            b = b.replace(' ', 'T');
+            e = e.replace(' ', 'T');
+
+            // If only date and no time then add explicit zero time
+            if (b.length() == 10) {
+                b = b + "T00:00:00";
+            }
+            if (e.length() == 10) {
+                e = e + "T00:00:00";
+            }
+
+            if (n == null || n.isEmpty()) {
+                n = "1";
+            }
+
+            Instant begin = LocalDateTime.parse(b).atZone(
+                    ZoneId.systemDefault()).toInstant();
+            Instant end = LocalDateTime.parse(e).atZone(
+                    ZoneId.systemDefault()).toInstant();
+
+            String deployment = "ops";
+            if (m != null && !m.trim().isEmpty()) {
+                deployment = m;
+            }
+
+            IntervalWebService service = new IntervalWebService(deployment);
+
+            metadata = service.findMetadata(c);
+            if (metadata == null) {
+                throw new Exception("Unable to find channel: '" + c + "' in deployment: '" + deployment + "'");
+            }
+
+            if (metadata.getType() != FloatEvent.class) {
+                throw new IllegalArgumentException("This myStats only supports FloatEvents - not '" + metadata.getType().getName() + "'.");
+            }
+
+            long numBins;
+            try {
+                numBins = Long.parseLong(n);
+            } catch (NumberFormatException ex) {
+                throw new Exception("Error parsing number of bins (n): '" + n + "'");
+            }
+            if (numBins < 1) {
+                throw new Exception("Number of bins must be >= 1.");
+            }
+
+            boolean updatesOnly = (d != null);
+
+            // Don't tell client to cache response if contains future bounds!
+            if (end.isAfter(Instant.now())) {
+                CacheAndEncodingFilter.disableCaching(response);
+            } else {
+                response.setHeader("Cache-Control", "private");
+            }
+
+            PointWebService pws = new PointWebService(deployment);
+            Event priorEvent = pws.findEvent(metadata, updatesOnly, begin, true, true, false);
+
+            double interval = ((end.getEpochSecond() + end.getNano() / 1_000_000_000d) - (begin.getEpochSecond() + begin.getNano() / 1_000_000_000d)) / numBins;
+            Instant binBegin, binEnd = begin;
+            for (int i = 1; i <= numBins; i++) {
+                binBegin = binEnd;
+                if (i == numBins) {
+                    binEnd = end;
+                } else {
+                    binEnd = binBegin.plusSeconds((long) interval);
+                }
+                // Since we provide a priorPoint, the underlying stream should be a BoundaryAwareStream.
+                try (FloatAnalysisStream fas = new FloatAnalysisStream(service.openEventStream(metadata, updatesOnly, binBegin, binEnd, priorEvent, metadata.getType()))) {
+                    while (fas.read() != null) {
+                        // Read through the entire stream.  We only want statistics from it
+                    }
+                    stats.put(binBegin, fas.getLatestStats());
+                }
+            }
+
+
+        } catch (Exception ex) {
+            LOGGER.log(Level.SEVERE, "Unable to service request", ex);
+            errorReason = ex.getMessage();
+
+            try {
+                if (stream != null) {
+                    stream.close();
+                    stream = null;
+                }
+            } catch (Exception closeIssue) {
+                System.err.println("Unable to close stream");
+            }
+        }
+
+        DateTimeFormatter timestampFormatter = FormatUtil.getInstantFormatter(f);
+        DecimalFormat decimalFormatter = FormatUtil.getDecimalFormat(v);
+        boolean formatAsMillisSinceEpoch = (u != null);
+        boolean adjustMillisWithServerOffset = (a != null);
+
+        OutputStream out = response.getOutputStream();
+
+        if (jsonp != null) {
+            out.write((jsonp + "(").getBytes(StandardCharsets.UTF_8));
+        }
+
+        try (JsonGenerator gen = Json.createGenerator(out)) {
+            gen.writeStartObject();
+
+            if (errorReason != null) {
+                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                gen.write("error", errorReason);
+            } else {
+                if (metadata != null) {
+                    gen.write("datatype", metadata.getMyaType().name());
+                    gen.write("datasize", metadata.getSize());
+                    gen.write("datahost", metadata.getHost());
+                    if (metadata.getIoc() == null) {
+                        gen.writeNull("ioc");
+                    } else {
+                        gen.write("ioc", metadata.getIoc());
+                    }
+                    gen.write("active", metadata.isActive());
+                }
+
+                gen.writeStartArray("data");
+
+                long dataLength = 0;
+                if (stats.isEmpty()) {
+                    // Presumably there is an error reason
+                } else {
+                    dataLength = generateStatisticsStream(gen, stats, timestampFormatter, decimalFormatter,
+                            formatAsMillisSinceEpoch, adjustMillisWithServerOffset);
+                }
+
+                gen.writeEnd();
+                gen.write("returnCount", dataLength);
+            }
+            gen.writeEnd();
+            gen.flush();
+        }
+        if (jsonp != null) {
+            out.write((");").getBytes(StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/src/main/java/org/jlab/myquery/MyStatsController.java
+++ b/src/main/java/org/jlab/myquery/MyStatsController.java
@@ -20,6 +20,10 @@ import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * This class provides functionality similar to the command line application myStats.
+ * @author adamc
+ */
 @WebServlet(name = "MyStatsController", value = "/mystats")
 public class MyStatsController extends QueryController {
     private static final Logger LOGGER = Logger.getLogger(MyStatsController.class.getName());

--- a/src/main/java/org/jlab/myquery/QueryController.java
+++ b/src/main/java/org/jlab/myquery/QueryController.java
@@ -151,7 +151,7 @@ public class QueryController extends HttpServlet {
     }
 
     /**
-     * This methods write a stream of RunningStatistics associated with a given start time to a JSON generator.
+     * This method write a stream of RunningStatistics associated with a given start time to a JSON generator.
      * @param gen The JSON generator to write them to
      * @param stats The Map of timestamps to RunningStatistics that will be written to the JSON generator
      * @param timestampFormatter How to format timestamps

--- a/src/main/java/org/jlab/myquery/QueryController.java
+++ b/src/main/java/org/jlab/myquery/QueryController.java
@@ -168,7 +168,6 @@ public class QueryController extends HttpServlet {
             RunningStatistics stat = stats.get(begin);
             gen.writeStartObject();
             FormatUtil.writeTimestampJSON(gen, "begin", begin, formatAsMillisSinceEpoch, adjustMillisWithServerOffset, timestampFormatter);
-            gen.write("begin", begin.toString());
             gen.write("eventCount", stat.getEventCount());
             gen.write("updateCount", stat.getUpdateCount());
 

--- a/src/main/webapp/WEB-INF/views/index.jsp
+++ b/src/main/webapp/WEB-INF/views/index.jsp
@@ -14,10 +14,16 @@
             </li>
             <li>
                 <h2><a href="/myquery/interval-form.html">interval</a></h2>
-            </li>            
+            </li>
             <li>
                 <h2><a href="/myquery/point-form.html">point</a></h2>
-            </li>            
+            </li>
+            <li>
+                <h2><a href="/myquery/mysampler-form.html">mysampler</a></h2>
+            </li>
+            <li>
+                <h2><a href="/myquery/mystats-form.html">mystats</a></h2>
+            </li>
         </ul>
         <div id="version">Version: ${initParam.releaseNumber} (${initParam.releaseDate})</div> 
     </body>

--- a/src/main/webapp/interval-form.html
+++ b/src/main/webapp/interval-form.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="">
     <head>
         <link rel="stylesheet" type="text/css" href="resources/css/myquery.css" />
         <title>myquery interval</title>
@@ -21,7 +21,7 @@
                             <input id="b" name="b" type="text" placeholder="YYYY-MM-DD[ hh:mm:[ss]]"/> 
                         </li>
                         <li>
-                            <label for="b">End date (e): </label>
+                            <label for="e">End date (e): </label>
                             <input id="e" name="e" type="text" placeholder="YYYY-MM-DD[ hh:mm:[ss]]"/> 
                         </li>
                         <li>

--- a/src/main/webapp/mysampler-form.html
+++ b/src/main/webapp/mysampler-form.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="">
     <head>
         <link rel="stylesheet" type="text/css" href="resources/css/myquery.css" />
         <title>myquery mysampler</title>

--- a/src/main/webapp/mysampler-form.html
+++ b/src/main/webapp/mysampler-form.html
@@ -26,8 +26,8 @@
 
                         </li>
                         <li>
-                            <label for="s">Sample Interval in ms (s): </label>
-                            <input id="s" name="s" type="number"/>
+                            <label for="e">Sample Interval in ms (e): </label>
+                            <input id="e" name="e" type="number"/>
                         </li>
                         <li>
                             <label for="m">Mya deployment (m): </label>

--- a/src/main/webapp/mysampler-form.html
+++ b/src/main/webapp/mysampler-form.html
@@ -26,8 +26,8 @@
 
                         </li>
                         <li>
-                            <label for="e">Sample Interval in ms (e): </label>
-                            <input id="e" name="e" type="number"/>
+                            <label for="s">Sample Interval in ms (s): </label>
+                            <input id="s" name="s" type="number"/>
                         </li>
                         <li>
                             <label for="m">Mya deployment (m): </label>

--- a/src/main/webapp/mysampler-form.html
+++ b/src/main/webapp/mysampler-form.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <link rel="stylesheet" type="text/css" href="resources/css/myquery.css" />
+        <title>myquery mysampler</title>
+        <meta charset="UTF-8">
+    </head>
+    <body>
+        <h1>mysampler query</h1>
+        <p>All options but channel, time, number of samples, and sample interval are optional.</p>
+        <form action="mysampler" method="get">
+            <div id ="input-panel">
+                <div id="text-panel">
+                    <ul>
+                        <li>
+                            <label for="c">Channel (c): </label>
+                            <input id="c" name="c" type="text"/> 
+                        </li>
+                        <li>
+                            <label for="b">Begin date (b): </label>
+                            <input id="b" name="b" type="text" placeholder="YYYY-MM-DD[ hh:mm:[ss]]"/> 
+                        </li>
+                        <li>
+                            <label for="n">Number of Samples (n): </label>
+                            <input id="n" name="n" type="number"/>
+
+                        </li>
+                        <li>
+                            <label for="s">Sample Interval in ms (s): </label>
+                            <input id="s" name="s" type="number"/>
+                        </li>
+                        <li>
+                            <label for="m">Mya deployment (m): </label>
+                            <input id="m" name="m" type="text" placeholder="default = ops"/> 
+                        </li>
+                        <li>
+                            <label for="f">Fractional time digits (f): </label>
+                            <input id="f" name="f" type="text" placeholder="default = 0"/> 
+                        </li>
+                        <li>
+                            <label for="v">Fractional value digits (v): </label>
+                            <input id="v" name="v" type="text" placeholder="default = 6"/> 
+                        </li>
+                    </ul>
+                </div>
+
+                <div id="checkbox-panel">
+                    <ul>
+                        <li>
+                            <label for="d">Data update events only (d): </label>
+                            <input id="d" name="d" type="checkbox"/> 
+                        </li>                        
+                        <li>
+                            <label for="s">Enumerations as string (s): </label>
+                            <input id="s" name="s" type="checkbox"/> 
+                        </li>
+                        <li>
+                            <label for="u">Timestamps as milliseconds from UNIX Epoch (u): </label>
+                            <input id="u" name="u" type="checkbox"/> 
+                        </li>
+                        <li>
+                            <label for="a">Adjust millis to server timezone offset (a): </label>
+                            <input id="a" name="a" type="checkbox"/>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <input type="submit"/>
+        </form>
+    </body>
+</html>

--- a/src/main/webapp/mystats-form.html
+++ b/src/main/webapp/mystats-form.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="">
+    <head>
+        <link rel="stylesheet" type="text/css" href="resources/css/myquery.css" />
+        <title>myquery mystats</title>
+        <meta charset="UTF-8">
+    </head>
+    <body>
+        <h1>mystats query</h1>
+        <p>This query mimics the major functionality of myStats with the added benefit of allowing for statistics to
+        be easily computed in bins of time during a larger interval.</p>
+        <p>All options but channel, begin, and end are optional.</p>
+        <p>Note:  This only works with FloatEvents (e.g. DBR_DOUBLE)</p>
+        <form action="mystats" method="get">
+            <div id ="input-panel">
+                <div id="text-panel">
+                    <ul>
+                        <li>
+                            <label for="c">Channel (c): </label>
+                            <input id="c" name="c" type="text"/> 
+                        </li>
+                        <li>
+                            <label for="b">Begin date (b): </label>
+                            <input id="b" name="b" type="text" placeholder="YYYY-MM-DD[ hh:mm:[ss]]"/>
+                        </li>
+                        <li>
+                            <label for="e">End date (e): </label>
+                            <input id="e" name="e" type="text" placeholder="YYYY-MM-DD[ hh:mm:[ss]]"/>
+                        </li>
+                        <li>
+                            <label for="n">Number of bins (n): </label>
+                            <input id="n" name="n" type="number" placeholder="1"/>
+
+                        </li>
+                        <li>
+                            <label for="m">Mya deployment (m): </label>
+                            <input id="m" name="m" type="text" placeholder="default = ops"/> 
+                        </li>
+                        <li>
+                            <label for="f">Fractional time digits (f): </label>
+                            <input id="f" name="f" type="text" placeholder="default = 0"/>
+                        </li>
+                        <li>
+                            <label for="v">Fractional value digits (v): </label>
+                            <input id="v" name="v" type="text" placeholder="default = 6"/> 
+                        </li>
+                    </ul>
+                </div>
+                <div id="checkbox-panel">
+                    <ul>
+                        <li>
+                            <label for="d">Data update events only (d): </label>
+                            <input id="d" name="d" type="checkbox"/> 
+                        </li>
+                        <li>
+                            <label for="u">Timestamps as milliseconds from UNIX Epoch (u): </label>
+                            <input id="u" name="u" type="checkbox"/> 
+                        </li>
+                        <li>
+                            <label for="a">Adjust millis to server timezone offset (a): </label>
+                            <input id="a" name="a" type="checkbox"/>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <input type="submit"/>
+        </form>
+    </body>
+</html>


### PR DESCRIPTION
This branch includes two main features and a list of small fixes.  The two new features are the inclusion of dedicated end points providing similar functionality as the mySampler and myStats command line applications.  Both provide core functionality, but ignore more niche features.  The mystats service does allow for binning of results (e.g., mean value for every hour bin).  These are coded in native java and leverage the recently updated jmyapi.  These are needed to move other apps off older legacy services that merely wrap the command line tools.

Other fixes:
- Minor html errors in query forms
- Update the mysampler option in the interval query to use the new jmyapi MySamplerStream for in application sampling from a single database query (prior option would make a database query per sample)
