### PR TITLE
myStats JSONP fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,10 @@ plugins {
 }
 
 description = "MYA web-based query tool"
-version = '4.0.0'
+version = '4.0.1'
 
 ext {
-    releaseDate = 'May 16, 2023'
+    releaseDate = 'June 20, 2023'
 }
 
 tasks.withType(JavaCompile) {

--- a/src/integration/java/org/jlab/myquery/MySamplerQueryTest.java
+++ b/src/integration/java/org/jlab/myquery/MySamplerQueryTest.java
@@ -5,6 +5,7 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
 import org.junit.Test;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.URI;
@@ -1082,6 +1083,23 @@ public class MySamplerQueryTest {
         try(JsonReader reader = Json.createReader(new StringReader(response.body()))) {
             JsonObject json = reader.readObject();
             assertEquals(exp, json.toString());
+        }
+    }
+
+    @Test
+    public void jsonpTest() throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder().uri(URI.create("http://localhost:8080/myquery/mysampler?c=channel1,channel2&b=2019-08-12+23%3A59%3A00&n=5&s=15000&m=docker&f=6&v=&jsonp=1234test")).build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+
+        String exp = "1234test({\"channels\":{\"channel1\":{\"metadata\":{\"name\":\"channel1\",\"datatype\":\"DBR_DOUBLE\",\"datasize\":1,\"datahost\":\"mya\",\"ioc\":null,\"active\":true},\"data\":[{\"d\":\"2019-08-12 23:59:00.000000\",\"v\":94.550102},{\"d\":\"2019-08-12 23:59:15.000000\",\"v\":94.987701},{\"d\":\"2019-08-12 23:59:30.000000\",\"v\":94.651604},{\"d\":\"2019-08-12 23:59:45.000000\",\"v\":94.292702},{\"d\":\"2019-08-13 00:00:00.000000\",\"v\":95.179703}],\"returnCount\":5},\"channel2\":{\"metadata\":{\"name\":\"channel2\",\"datatype\":\"DBR_ENUM\",\"datasize\":1,\"datahost\":\"mya\",\"ioc\":null,\"active\":true},\"labels\":[{\"d\":\"2016-08-12 13:00:49.000000\",\"value\":[\"BEAM SYNC ONLY\",\"PULSE MODE VL\",\"TUNE MODE\",\"CW MODE (DC)\",\"USER MODE\"]}],\"data\":[{\"d\":\"2019-08-12 23:59:00.000000\",\"v\":3},{\"d\":\"2019-08-12 23:59:15.000000\",\"v\":3},{\"d\":\"2019-08-12 23:59:30.000000\",\"v\":3},{\"d\":\"2019-08-12 23:59:45.000000\",\"v\":3},{\"d\":\"2019-08-13 00:00:00.000000\",\"v\":3}],\"returnCount\":5}}});";
+
+        String result;
+        try (BufferedReader reader = new BufferedReader(new StringReader(response.body()))) {
+            result = reader.readLine();
+            assertEquals(exp, result);
         }
     }
 }

--- a/src/integration/java/org/jlab/myquery/MyStatsQueryTest.java
+++ b/src/integration/java/org/jlab/myquery/MyStatsQueryTest.java
@@ -5,6 +5,7 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
 import org.junit.Test;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.URI;
@@ -247,6 +248,23 @@ public class MyStatsQueryTest {
         try (JsonReader reader = Json.createReader(new StringReader(response.body()))) {
             JsonObject json = reader.readObject();
             assertEquals(exp, json.toString());
+        }
+    }
+
+    @Test
+    public void jsonpTest() throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder().uri(URI.create("http://localhost:8080/myquery/mystats?c=channel1,channel4&b=2019-08-12&e=2019-08-12+01%3A00%3A00&n=1&m=docker&f=3&v=2&jsonp=1234test")).build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+
+        String exp = "1234test({\"channels\":{\"channel1\":{\"metadata\":{\"name\":\"channel1\",\"datatype\":\"DBR_DOUBLE\",\"datasize\":1,\"datahost\":\"mya\",\"ioc\":null,\"active\":true},\"data\":[{\"begin\":\"2019-08-12 00:00:00.000\",\"eventCount\":1716,\"updateCount\":1715,\"duration\":3594.42,\"integration\":341342.2,\"max\":96.95,\"mean\":94.96,\"min\":0,\"rms\":95.27,\"stdev\":7.59}],\"returnCount\":1},\"channel4\":{\"metadata\":{\"name\":\"channel4\",\"datatype\":\"DBR_DOUBLE\",\"datasize\":1,\"datahost\":\"mya\",\"ioc\":null,\"active\":true},\"data\":[{\"begin\":\"2019-08-12 00:00:00.000\",\"eventCount\":0,\"updateCount\":0,\"duration\":null,\"integration\":null,\"max\":null,\"mean\":null,\"min\":null,\"rms\":null,\"stdev\":null}],\"returnCount\":1}}});";
+
+        String result;
+        try (BufferedReader reader = new BufferedReader(new StringReader(response.body()))) {
+            result = reader.readLine();
+            assertEquals(exp, result);
         }
     }
 }

--- a/src/main/java/org/jlab/myquery/MyStatsController.java
+++ b/src/main/java/org/jlab/myquery/MyStatsController.java
@@ -217,9 +217,10 @@ public class MyStatsController extends QueryController {
             }
             gen.writeEnd();
             gen.flush();
-        }
-        if (jsonp != null) {
-            out.write((");").getBytes(StandardCharsets.UTF_8));
+
+            if (jsonp != null) {
+                out.write((");").getBytes(StandardCharsets.UTF_8));
+            }
         }
     }
 }


### PR DESCRIPTION
One of the JSONP endpoints was broken as it would not return the closing ");" on it's response.  This update fixes that simple problem and adds JSONP integration tests to the end points I recently added in v4.0.0.