### PR TITLE
Updatemysampler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,10 @@ plugins {
 }
 
 description = "MYA web-based query tool"
-version = '6.0.2'
+version = '6.1.0'
 
 ext {
-    releaseDate = 'Sep 26 2023'
+    releaseDate = 'Dec 12, 2023'
 }
 
 tasks.withType(JavaCompile) {
@@ -35,7 +35,7 @@ configurations {
 }
 
 dependencies {
-    implementation 'org.jlab:jmyapi:8.0.0',
+    implementation 'org.jlab:jmyapi:9.0.0',
                    'org.eclipse.parsson:parsson:1.1.1'
 	providedCompile 'jakarta.servlet:jakarta.servlet-api:6.0.0'
     testImplementation 'junit:junit:4.13.2'

--- a/src/main/webapp/mysampler-form.html
+++ b/src/main/webapp/mysampler-form.html
@@ -41,6 +41,14 @@
                             <label for="v">Significant figures (v): </label>
                             <input id="v" name="v" type="text" placeholder="default = 6"/> 
                         </li>
+                        <li>
+                            <label for="x">Sample Strategy (v): </label>
+                            <select id="x" name="x">
+                                <option value="n">Many Events Per Sample</option>
+                                <option value="s">Few Events Per Sample</option>
+                            </select>
+                        </li>
+
                     </ul>
                 </div>
 


### PR DESCRIPTION
Update the mysampler endpoint to support different sampling strategies.  Previously it used the version jmyapi that tried to change strategies on the fly, but this had it's own performance issues.  Now the myquery user specifies the sampling strategy and the matching MySamplerStream is created without any dynamic switching involved.